### PR TITLE
docs: removed NPM part and added Debian stuff

### DIFF
--- a/docs/Dashactyl/installation.md
+++ b/docs/Dashactyl/installation.md
@@ -27,12 +27,14 @@ sudo apt update && sudo apt upgrade
 # installing git CLI
 sudo apt install git
 
-# installing NPM
-sudo apt install npm
-
-# installing NodeJS
+# installing NodeJS & NPM on Ubuntu
 curl -fsSL https://deb.nodesource.com/setup_14.x | sudo bash -
-sudo apt install nodejs
+sudo apt install -y nodejs
+
+# installing NodeJS & NPM on Debian, as root
+curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+apt install -y nodejs
+
 ```
 
 You can check the versions with the following commands:


### PR DESCRIPTION
I've removed the part where it says "sudo apt install npm", since that will broke stuff if you're on older Debian versions. (well not broke it but you have to manually update the npm version again.)
And also the bash install script from nodesource installs NPM & NodeJS.